### PR TITLE
base-linux: Fix missing SYS_waitpid syscall on 64bit linux

### DIFF
--- a/base-linux/src/core/include/core_linux_syscalls.h
+++ b/base-linux/src/core/include/core_linux_syscalls.h
@@ -112,7 +112,8 @@ inline int lx_setgid(unsigned int gid)
  */
 inline int lx_pollpid()
 {
-	return lx_syscall(SYS_waitpid, -1 /* any PID */, (int *)0, 1 /* WNOHANG */);
+	return lx_syscall(SYS_wait4, -1 /* any PID */, (int *)0, 1 /* WNOHANG */,
+	                  (struct rusage *)0);
 }
 
 


### PR DESCRIPTION
SYS_waitpid is only available on 32bit Linux. Replacing SYS_waitpid
with SYS_wait4 which is available on both architectures.

This fixes the following compile error:

In file included from .../base-linux/src/core/cpu_session_extension.cc:11:0:
.../base-linux/src/core/include/core_linux_syscalls.h: In function ‘int lx_pollpid()’:
.../base-linux/src/core/include/core_linux_syscalls.h:115:20: error: ‘SYS_waitpid’ was not declared in this scope

The call "make run/failsafe" was succesful after applying this fix:

spawn ./core
int main(): --- create local services ---
int main(): --- start init ---
int main(): transferred 17592186044415 MB to init
int main(): --- init created, waiting for exit condition ---
[init] Could not open file "ld.lib.so"
[init -> test-failsafe] --- failsafe test started ---
[init -> test-failsafe] create child 0
Quota exceeded! amount=4096, size=4096, consumed=4096
[init -> test-failsafe] upgrading quota donation for SIGNAL session
[init -> test-failsafe -> child] going to produce a segmentation fault...
[init -> test-failsafe] got exception for child 0
[init -> test-failsafe] create child 1
[init -> test-failsafe -> child] going to produce a segmentation fault...
[init -> test-failsafe] got exception for child 1
[init -> test-failsafe] create child 2
[init -> test-failsafe -> child] going to produce a segmentation fault...
[init -> test-failsafe] got exception for child 2
[init -> test-failsafe] create child 3
[init -> test-failsafe -> child] going to produce a segmentation fault...
[init -> test-failsafe] got exception for child 3
[init -> test-failsafe] create child 4
[init -> test-failsafe -> child] going to produce a segmentation fault...
[init -> test-failsafe] got exception for child 4
[init -> test-failsafe] --- finished failsafe test ---
